### PR TITLE
fix: update Cloudflare token validation length

### DIFF
--- a/src/components/login.tsx
+++ b/src/components/login.tsx
@@ -29,7 +29,7 @@ function Login() {
       token: "",
     },
     validate: {
-      token: (value) => value.trim().length !== 40,
+      token: (value) => (value.trim().length > 40 ? null : "Token too short"),
     },
   });
 
@@ -45,7 +45,7 @@ function Login() {
         />
         <Button
           type="submit"
-          disabled={tokenForm.values.token.trim().length !== 40}
+          disabled={tokenForm.values.token.trim().length < 40}
           loading={isLoading}>
           {LL.SAVE()}
         </Button>


### PR DESCRIPTION
Hi, it looks like Cloudflare Token API now are longer and not 40 chars long anymore.